### PR TITLE
Fixed abstract impl for abitrary input dimensions.

### DIFF
--- a/flute/ops.py
+++ b/flute/ops.py
@@ -11,10 +11,9 @@ def _qgemm_simple_abstract(
     num_bits: int,
     group_size: int,
 ) -> torch.Tensor:
-    M = input.shape[0]
     N = scales.shape[0]
     return torch.empty(
-        (M, N),
+        input.shape[:-1] + (N,),
         dtype=input.dtype,
         device=input.device)
 


### PR DESCRIPTION
`_qgemm_simple_abstract` didn't properly handle the fact that input tensors can have more than 2 dimensions.

This PR fixes it.